### PR TITLE
Fix type punning warning

### DIFF
--- a/kaitai/kaitaistream.cpp
+++ b/kaitai/kaitaistream.cpp
@@ -256,7 +256,7 @@ float kaitai::kstream::read_f4be() {
 #if __BYTE_ORDER == __LITTLE_ENDIAN
     t = bswap_32(t);
 #endif
-    type_pun(&out, &t);
+    type_pun(out, t);
     return out;
 }
 
@@ -267,7 +267,7 @@ double kaitai::kstream::read_f8be() {
 #if __BYTE_ORDER == __LITTLE_ENDIAN
     t = bswap_64(t);
 #endif
-    type_pun(&out, &t);
+    type_pun(out, t);
     return out;
 }
 
@@ -282,7 +282,7 @@ float kaitai::kstream::read_f4le() {
 #if __BYTE_ORDER == __BIG_ENDIAN
     t = bswap_32(t);
 #endif
-    type_pun(&out, &t);
+    type_pun(out, t);
     return out;
 }
 
@@ -293,7 +293,7 @@ double kaitai::kstream::read_f8le() {
 #if __BYTE_ORDER == __BIG_ENDIAN
     t = bswap_64(t);
 #endif
-    type_pun(&out, &t);
+    type_pun(out, t);
     return out;
 }
 

--- a/kaitai/kaitaistream.cpp
+++ b/kaitai/kaitaistream.cpp
@@ -251,20 +251,24 @@ uint64_t kaitai::kstream::read_u8le() {
 
 float kaitai::kstream::read_f4be() {
     uint32_t t;
+    float out;
     m_io->read(reinterpret_cast<char *>(&t), 4);
 #if __BYTE_ORDER == __LITTLE_ENDIAN
     t = bswap_32(t);
 #endif
-    return reinterpret_cast<float&>(t);
+    type_pun(&out, &t);
+    return out;
 }
 
 double kaitai::kstream::read_f8be() {
     uint64_t t;
+    double out;
     m_io->read(reinterpret_cast<char *>(&t), 8);
 #if __BYTE_ORDER == __LITTLE_ENDIAN
     t = bswap_64(t);
 #endif
-    return reinterpret_cast<double&>(t);
+    type_pun(&out, &t);
+    return out;
 }
 
 // ........................................................................
@@ -273,20 +277,24 @@ double kaitai::kstream::read_f8be() {
 
 float kaitai::kstream::read_f4le() {
     uint32_t t;
+    float out;
     m_io->read(reinterpret_cast<char *>(&t), 4);
 #if __BYTE_ORDER == __BIG_ENDIAN
     t = bswap_32(t);
 #endif
-    return reinterpret_cast<float&>(t);
+    type_pun(&out, &t);
+    return out;
 }
 
 double kaitai::kstream::read_f8le() {
     uint64_t t;
+    double out;
     m_io->read(reinterpret_cast<char *>(&t), 8);
 #if __BYTE_ORDER == __BIG_ENDIAN
     t = bswap_64(t);
 #endif
-    return reinterpret_cast<double&>(t);
+    type_pun(&out, &t);
+    return out;
 }
 
 // ========================================================================

--- a/kaitai/kaitaistream.h
+++ b/kaitai/kaitaistream.h
@@ -285,7 +285,7 @@ inline auto to_signed(From from) {
 template<class Output, class Read>
 inline void type_pun(Output& output, Read& read)
 {
-    static_assert(sizeof(output) == sizeof(output), "Type sizes don't match");
+    static_assert(sizeof(read) == sizeof(output), "Type sizes don't match");
     std::memcpy(&output, &read, sizeof(output));
 }
 

--- a/kaitai/kaitaistream.h
+++ b/kaitai/kaitaistream.h
@@ -283,10 +283,10 @@ inline auto to_signed(From from) {
 }
 
 template<class Output, class Read>
-inline void type_pun(const Output& output, const Read& read)
+inline void type_pun(Output& output, Read& read)
 {
-    static_assert(sizeof(Read) == sizeof(Output), "Type sizes don't match");
-    std::memcpy(output, read, sizeof(*output));
+    static_assert(sizeof(output) == sizeof(output), "Type sizes don't match");
+    std::memcpy(&output, &read, sizeof(output));
 }
 
 }

--- a/kaitai/kaitaistream.h
+++ b/kaitai/kaitaistream.h
@@ -9,6 +9,7 @@
 #include <stdint.h>
 #include <sys/types.h>
 #include <limits>
+#include <cstring>
 
 namespace kaitai {
 
@@ -279,6 +280,13 @@ inline auto to_signed(From from) {
     }
 
     throw std::runtime_error("toSigned: Invalid casting");
+}
+
+template<class Output, class Read>
+inline void type_pun(const Output& output, const Read& read)
+{
+    static_assert(sizeof(Read) == sizeof(Output), "Type sizes don't match");
+    std::memcpy(output, read, sizeof(*output));
 }
 
 }


### PR DESCRIPTION
Using memcpy is (as far as I know) the best alternative for type punning unrelated types.
Union punning will produce UB on C++17 and reinterpret_cast will cause strict aliasing violation.